### PR TITLE
fix: timeline entry date matches selected date

### DIFF
--- a/src/app/plants/[id]/page.tsx
+++ b/src/app/plants/[id]/page.tsx
@@ -8,7 +8,18 @@ import Link from "next/link";
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
+  // Date-only strings ("YYYY-MM-DD") are parsed as UTC midnight by `new Date()`,
+  // which can shift the displayed day in local time zones. Parse them as local
+  // dates so the displayed date matches what the user selected.
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  const date = dateOnlyMatch
+    ? new Date(
+        Number(dateOnlyMatch[1]),
+        Number(dateOnlyMatch[2]) - 1,
+        Number(dateOnlyMatch[3]),
+      )
+    : new Date(iso);
+  return date.toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",


### PR DESCRIPTION
## Why

When adding a timeline entry, the date the user selected didn't match the date displayed on the entry.

## What

`<input type="date">` returns a `YYYY-MM-DD` string. `new Date("YYYY-MM-DD")` parses it as **UTC midnight**, so `toLocaleDateString` in time zones west of UTC (e.g. ET) rendered the previous day.

`formatDate` now detects date-only strings and constructs them as local dates. Full ISO timestamps still take the original code path.