### PR TITLE
feat(dev-auth): add gh CLI login bypass for local development

### DIFF
--- a/src/app/api/dev-auth/gh-login/route.ts
+++ b/src/app/api/dev-auth/gh-login/route.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db, schema } from "@/lib/db";
+import { fetchGhUser, GhCliError } from "@/lib/dev-gh-user";
+import {
+  getRequestOrigin,
+  getSafeCallbackUrl,
+  isDevAuthEnabled,
+  SESSION_COOKIE_NAMES,
+  validateDevAuthToken,
+} from "@/app/api/dev-auth/shared";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const SESSION_DURATION_DAYS = 30;
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const requestUrl = new URL(request.url);
+
+  if (!isDevAuthEnabled()) {
+    return NextResponse.json({ error: "Development auth is not enabled." }, { status: 404 });
+  }
+
+  const tokenError = validateDevAuthToken(requestUrl);
+  if (tokenError) {
+    return tokenError;
+  }
+
+  let ghUser;
+  try {
+    ghUser = await fetchGhUser();
+  } catch (err) {
+    if (err instanceof GhCliError) {
+      console.error("[dev-auth/gh-login]", err.message, err.hint ?? "");
+      return NextResponse.json(
+        { error: err.message, hint: err.hint ?? null },
+        { status: 502 }
+      );
+    }
+    console.error("[dev-auth/gh-login] unexpected error", err);
+    return NextResponse.json({ error: "Failed to read gh CLI identity." }, { status: 500 });
+  }
+
+  const userId = `dev-gh-${ghUser.id}`;
+  const username = `dev-gh-${ghUser.login}`;
+  const email = `dev-gh-${ghUser.login}@users.noreply.localhost`;
+  const name = ghUser.name ?? ghUser.login;
+  const sessionToken = `${randomUUID()}${randomUUID()}`.replaceAll("-", "");
+  const expires = new Date(Date.now() + SESSION_DURATION_DAYS * 24 * 60 * 60 * 1000);
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(schema.users)
+        .values({
+          id: userId,
+          name,
+          email,
+          username,
+          image: ghUser.avatar_url,
+          location: ghUser.location,
+        })
+        .onConflictDoUpdate({
+          target: schema.users.id,
+          set: {
+            name,
+            email,
+            username,
+            image: ghUser.avatar_url,
+            location: ghUser.location,
+          },
+        });
+
+      await tx
+        .insert(schema.userSettings)
+        .values({
+          userId,
+          theme: "green",
+          gardenName: `${name}'s Garden`,
+          location: ghUser.location,
+        })
+        .onConflictDoNothing();
+
+      await tx.delete(schema.sessions).where(eq(schema.sessions.userId, userId));
+      await tx.insert(schema.sessions).values({
+        sessionToken,
+        userId,
+        expires,
+      });
+    });
+  } catch (err) {
+    console.error("GET /api/dev-auth/gh-login failed:", err);
+    const message = err instanceof Error ? err.message : "Failed to create development session";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const requestOrigin = getRequestOrigin(request, requestUrl);
+  const response = NextResponse.redirect(getSafeCallbackUrl(requestUrl, requestOrigin));
+
+  for (const cookieName of SESSION_COOKIE_NAMES) {
+    response.cookies.set({
+      name: cookieName,
+      value: sessionToken,
+      expires,
+      httpOnly: true,
+      sameSite: "lax",
+      secure: requestOrigin.startsWith("https://"),
+      path: "/",
+    });
+  }
+
+  return response;
+}

--- a/src/app/api/dev-auth/shared.ts
+++ b/src/app/api/dev-auth/shared.ts
@@ -40,6 +40,18 @@ export function getSafeCallbackUrl(requestUrl: URL, requestOrigin: string, defau
   return new URL(callbackUrl, requestOrigin);
 }
 
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+export function isLoopbackHostHeader(host: string | null | undefined): boolean {
+  if (!host) return false;
+  const first = host.split(",")[0]?.trim();
+  if (!first) return false;
+  const hostname = first.startsWith("[")
+    ? first.slice(0, first.indexOf("]") + 1)
+    : first.split(":")[0];
+  return LOOPBACK_HOSTNAMES.has(hostname);
+}
+
 export function validateDevAuthToken(requestUrl: URL): NextResponse | undefined {
   if (!isDevAuthEnabled()) {
     return NextResponse.json({ error: "Development auth is not enabled." }, { status: 404 });

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+
+interface LoginFormProps {
+  callbackUrl: string;
+  ghLoginHref: string | null;
+}
+
+export function LoginForm({ callbackUrl, ghLoginHref }: LoginFormProps) {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-bg-card p-8 shadow-md">
+        <div className="mb-6 text-center">
+          <span className="text-5xl">🌱</span>
+          <h1 className="mt-3 text-2xl font-bold text-text-primary">
+            The Seed Feed
+          </h1>
+          <p className="mt-2 text-sm text-text-secondary">
+            Track your plants, share your garden, and grow with fellow seeders.
+          </p>
+        </div>
+
+        <button
+          onClick={() => signIn("github", { callbackUrl })}
+          className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 font-medium text-white transition-colors hover:bg-gray-800"
+        >
+          <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          </svg>
+          Sign in with GitHub
+        </button>
+
+        {ghLoginHref ? (
+          <>
+            <div className="my-4 flex items-center gap-3 text-xs text-text-secondary">
+              <span className="h-px flex-1 bg-border" aria-hidden="true" />
+              <span>dev mode</span>
+              <span className="h-px flex-1 bg-border" aria-hidden="true" />
+            </div>
+            <a
+              href={ghLoginHref}
+              className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-bg-card px-4 py-3 font-medium text-text-primary transition-colors hover:bg-hover"
+            >
+              <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              <span>
+                Sign in with your <code className="rounded bg-hover px-1 py-0.5 text-xs">gh</code> CLI
+              </span>
+            </a>
+            <p className="mt-2 text-center text-xs text-text-secondary">
+              Local dev only. Reads identity from <code>gh api user</code> on the server host.
+            </p>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,44 +1,35 @@
-"use client";
+import { headers } from "next/headers";
+import { isLoopbackHostHeader } from "@/app/api/dev-auth/shared";
+import { LoginForm } from "./login-form";
 
-import { signIn } from "next-auth/react";
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+export const dynamic = "force-dynamic";
 
-function LoginForm() {
-  const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="w-full max-w-sm rounded-2xl border border-border bg-bg-card p-8 shadow-md">
-        <div className="mb-6 text-center">
-          <span className="text-5xl">🌱</span>
-          <h1 className="mt-3 text-2xl font-bold text-text-primary">
-            The Seed Feed
-          </h1>
-          <p className="mt-2 text-sm text-text-secondary">
-            Track your plants, share your garden, and grow with fellow seeders.
-          </p>
-        </div>
-
-        <button
-          onClick={() => signIn("github", { callbackUrl })}
-          className="flex w-full items-center justify-center gap-3 rounded-lg bg-gray-900 px-4 py-3 font-medium text-white transition-colors hover:bg-gray-800"
-        >
-          <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-          </svg>
-          Sign in with GitHub
-        </button>
-      </div>
-    </div>
-  );
+interface PageProps {
+  searchParams: Promise<{ callbackUrl?: string | string[] }>;
 }
 
-export default function LoginPage() {
-  return (
-    <Suspense fallback={<div className="flex min-h-[60vh] items-center justify-center"><span className="animate-pulse text-lg">Loading...</span></div>}>
-      <LoginForm />
-    </Suspense>
-  );
+function sanitizeCallback(raw: string | string[] | undefined): string {
+  if (typeof raw !== "string") return "/";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw;
+}
+
+export default async function LoginPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const callbackUrl = sanitizeCallback(params.callbackUrl);
+
+  const headersList = await headers();
+  const loopback = isLoopbackHostHeader(headersList.get("host"));
+  const devAuthEnabled =
+    process.env.NODE_ENV !== "production" &&
+    process.env.DEV_AUTH_ENABLED === "true";
+  const devAuthToken = process.env.DEV_AUTH_TOKEN;
+
+  let ghLoginHref: string | null = null;
+  if (devAuthEnabled && devAuthToken && loopback) {
+    const qs = new URLSearchParams({ token: devAuthToken, callbackUrl });
+    ghLoginHref = `/api/dev-auth/gh-login?${qs.toString()}`;
+  }
+
+  return <LoginForm callbackUrl={callbackUrl} ghLoginHref={ghLoginHref} />;
 }

--- a/src/lib/dev-gh-user.ts
+++ b/src/lib/dev-gh-user.ts
@@ -1,0 +1,89 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface GhUser {
+  id: number;
+  login: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+  location: string | null;
+}
+
+export class GhCliError extends Error {
+  readonly hint?: string;
+
+  constructor(message: string, hint?: string) {
+    super(message);
+    this.name = "GhCliError";
+    this.hint = hint;
+  }
+}
+
+interface ExecError extends NodeJS.ErrnoException {
+  stderr?: string | Buffer;
+  stdout?: string | Buffer;
+}
+
+function asString(value: string | Buffer | undefined): string {
+  if (!value) return "";
+  return typeof value === "string" ? value : value.toString("utf8");
+}
+
+export async function fetchGhUser(timeoutMs = 8000): Promise<GhUser> {
+  let stdout: string;
+  try {
+    const result = await execFileAsync("gh", ["api", "user"], {
+      timeout: timeoutMs,
+      env: { ...process.env, GH_PROMPT_DISABLED: "1", NO_COLOR: "1" },
+      maxBuffer: 1024 * 1024,
+    });
+    stdout = result.stdout;
+  } catch (err) {
+    const execErr = err as ExecError;
+    if (execErr?.code === "ENOENT") {
+      throw new GhCliError(
+        "The `gh` CLI is not installed on this machine.",
+        "Install it from https://cli.github.com/ (e.g. `brew install gh`) and run `gh auth login`."
+      );
+    }
+    const stderr = asString(execErr?.stderr).trim();
+    const lower = stderr.toLowerCase();
+    if (
+      lower.includes("authentication required") ||
+      lower.includes("not logged into") ||
+      lower.includes("to get started with github cli")
+    ) {
+      throw new GhCliError(
+        "The `gh` CLI is installed but not authenticated.",
+        "Run `gh auth login` on the machine running the Next.js server and try again."
+      );
+    }
+    throw new GhCliError(
+      `Failed to run \`gh api user\`: ${execErr?.message ?? "unknown error"}`,
+      stderr || undefined
+    );
+  }
+
+  let parsed: Partial<GhUser>;
+  try {
+    parsed = JSON.parse(stdout) as Partial<GhUser>;
+  } catch {
+    throw new GhCliError("`gh api user` returned non-JSON output.");
+  }
+
+  if (typeof parsed.id !== "number" || typeof parsed.login !== "string") {
+    throw new GhCliError("`gh api user` returned an unexpected payload (missing id/login).");
+  }
+
+  return {
+    id: parsed.id,
+    login: parsed.login,
+    name: typeof parsed.name === "string" ? parsed.name : null,
+    email: typeof parsed.email === "string" ? parsed.email : null,
+    avatar_url: typeof parsed.avatar_url === "string" ? parsed.avatar_url : null,
+    location: typeof parsed.location === "string" ? parsed.location : null,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a dev-only shortcut to sign in as your real GitHub identity by reading from the local `gh` CLI — bypassing the GitHub OAuth web flow when a developer hasn't (or can't) set up a valid OAuth App `client_id`.

The existing `dev-feeder`/`remote-feeder` shortcut signs you in as a fake user. This adds a parallel shortcut that signs you in as **you**.

## What changed

- **New endpoint** `GET /api/dev-auth/gh-login`
  - 404 in production (`NODE_ENV === "production"` or `DEV_AUTH_ENABLED !== "true"`).
  - Requires the existing Aspire-generated `DEV_AUTH_TOKEN` (`?token=...`).
  - Shells out to `gh api user` via `execFile` (timeout, `GH_PROMPT_DISABLED=1`, distinct errors for missing binary vs unauthenticated `gh`).
  - Upserts a user row keyed on `dev-gh-{githubId}` with **synthetic** email/username (`dev-gh-{login}@users.noreply.localhost` / `dev-gh-{login}`) so it can never collide with a future real GitHub OAuth signin.
  - Upsert + settings insert + session delete/insert run in one Drizzle transaction.
  - Sets the same `authjs.session-token` cookies as the existing dev-login route.
- **`/login` is now a server component** (`src/app/login/page.tsx`).
  - Reads `searchParams` and `headers()` (Next.js 16 async APIs).
  - Embeds `DEV_AUTH_TOKEN` into the gh-login link **only when** the request `Host` header is loopback. The token is never rendered into pages served via the dev tunnel.
  - The existing GitHub OAuth button moves into `login-form.tsx` (client child) with no behavior change.
- **`isLoopbackHostHeader()`** helper added to `src/app/api/dev-auth/shared.ts`. Does not trust `X-Forwarded-Host` and does not treat `0.0.0.0` as loopback.

## Security notes

- Token always required — the loopback check governs **rendering** the link, not the **auth decision** on the endpoint.
- Hidden in production: returns 404 unless `NODE_ENV !== "production"` AND `DEV_AUTH_ENABLED === "true"`.
- Synthetic email/username avoids unique-constraint collisions if the same dev later signs in via real GitHub OAuth.
- No changes to `apphost.ts`, NextAuth config, or middleware — `/api/dev-auth/*` is already a public path.

## Testing

- [x] `npx tsc --noEmit` passes.
- [x] `next build` succeeds; new dynamic route appears in the route table.
- [x] Manual: `aspire start`, open `http://localhost:3000/login`, click "Sign in with `gh` CLI", land on `/` as the gh-authenticated user.
- [ ] Manual: open the dev tunnel URL → confirm the gh-login button is **not** rendered (no token leak).
- [ ] Manual: `gh auth logout` → click the button → expect 502 with "gh CLI is installed but not authenticated".

## Out of scope

- Not fixing the real GitHub OAuth flow itself (separate concern — requires a valid `Ov23li...` client ID).
- Not changing the existing `dev-feeder`/`remote-feeder` shortcut.
